### PR TITLE
Title Update TOP theme to Lume version 3

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -211,7 +211,7 @@
     "name": "Top",
     "description": "A theme to build a website for a tech event.",
     "tags": ["event", "tech", "landing"],
-    "lume_version": 2,
+    "lume_version": 3,
     "author": {
       "name": "Óscar Otero",
       "url": "https://oscarotero.com"

--- a/themes.json
+++ b/themes.json
@@ -211,7 +211,7 @@
     "name": "Top",
     "description": "A theme to build a website for a tech event.",
     "tags": ["event", "tech", "landing"],
-    "lume_version": 3,
+    "lume_version": 2,
     "author": {
       "name": "Óscar Otero",
       "url": "https://oscarotero.com"


### PR DESCRIPTION
This PR updates the Lume version for the TOP theme from 2 to 3 in the themes.json file.

The TOP theme has already been upgraded to Lume 3 as mentioned in its [CHANGELOG.md](https://github.com/tarugoconf/TOP/blob/main/CHANGELOG.md#030---unreleased):

```
## [0.3.0] - Unreleased
### Changed
- Upgrade to Lume 3.
```

I'm experiencing a "Theme 'top' not found" error when trying to use the TOP theme with Lume 3, and I believe updating the version number in the registry might help resolve this issue.

However, I'm not entirely sure if simply changing the version number is sufficient or if there are additional adjustments needed in the registry for Lume 3 compatibility. I'd appreciate any guidance on whether this change is correct and complete, or if additional modifications are required.

Thank you for maintaining this great registry!